### PR TITLE
Introduce eslint.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -28,6 +28,19 @@ rules:
   no-unused-vars:
     - error
     - args: none
+  max-len:
+    - error
+    - code: 80
+  no-new-object:
+    - error
+  no-array-constructor:
+    - error
+  no-new-wrappers:
+    - error
+  no-multi-str:
+    - error
+  no-with:
+    - error
   react/jsx-uses-react:
     - error
   react/jsx-uses-vars:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,39 @@
+# TODO: Adopt Google JS style once it covers ES6.
+env:
+  browser: true
+  es6: true
+  jquery: true
+  webextensions: true
+extends: 'eslint:recommended'
+parserOptions:
+  ecmaFeatures:
+    experimentalObjectRestSpread: true
+    jsx: true
+  sourceType: module
+plugins:
+  - react
+rules:
+  indent:
+    - error
+    - 2
+  linebreak-style:
+    - error
+    - unix
+  quotes:
+    - error
+    - single
+  semi:
+    - error
+    - always
+  no-unused-vars:
+    - error
+    - args: none
+  react/jsx-uses-react:
+    - error
+  react/jsx-uses-vars:
+    - error
+  # Stijl specific: Allow printing to console since it's useful for end users
+  # to report bugs. Note that "end" users of this extension are actually
+  # developers :)
+  no-console:
+    - off

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "browserify src/index.js -o extension/dashboard.js -t [ babelify --plugins [ transform-object-rest-spread ] --presets [ es2015 react ] ]",
     "watch": "watchify src/index.js -v -d -o extension/dashboard.js -t [ babelify --plugins [ transform-object-rest-spread ] --presets [ es2015 react ] ]",
+    "lint": "eslint src",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -38,6 +39,8 @@
     "redux-thunk": "^2.1.0"
   },
   "devDependencies": {
+    "eslint": "^3.3.1",
+    "eslint-plugin-react": "^6.1.1",
     "watchify": "^3.7.0"
   }
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -99,7 +99,7 @@ export const refreshAll = () => {
           dispatch(finishRefreshSite(site.label, false));
           console.error(err);
         });
-      })
+      });
     }, () => {
       dispatch(showPermissionModal());
     });

--- a/src/backends/gerrit.js
+++ b/src/backends/gerrit.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import chromeAsync from '../chromeasync'
-import * as util from '../util'
+import chromeAsync from '../chromeasync';
+import * as util from '../util';
 
 export class GerritBackend {
   constructor(site) {
@@ -34,14 +34,14 @@ export class GerritBackend {
     let changesUrl =
         this.site_['url'] +
         '/changes/?o=DETAILED_ACCOUNTS&o=REVIEWED&o=DETAILED_LABELS';
-    queries.forEach((query, i) => {
+    queries.forEach((query) => {
       changesUrl += '&q=' + encodeURIComponent(query);
     });
 
     return fetch(changesUrl, {credentials: 'include'})
       .then((res) => res.text())
       .then((text) => {
-        const data = JSON.parse(text.substring(text.indexOf('\n') + 1))
+        const data = JSON.parse(text.substring(text.indexOf('\n') + 1));
         return this.parseResponse_(data, selfAddress);
       });
   }

--- a/src/backends/rietveld.js
+++ b/src/backends/rietveld.js
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-import chromeAsync from '../chromeasync'
-import * as util from '../util'
+import chromeAsync from '../chromeasync';
+import * as util from '../util';
 
 /**
  * The number of entries to be fetched.
@@ -87,7 +86,7 @@ export class RietveldBackend {
   doFetchOne_(issue) {
     const url = this.site_['url'] + '/api/' + issue + '?messages=True';
     return fetch(url, {credentials: 'include'}).then((res) => res.json());
-  };
+  }
 
   parseEntry_(entry, selfAddress) {
     let status;

--- a/src/backends/rietveld.js
+++ b/src/backends/rietveld.js
@@ -70,7 +70,8 @@ export class RietveldBackend {
       .then((res) => res.json()).then((data) => {
         const promises = [];
         data['results'].forEach((entry) => {
-          // For open review, we need detailed messages to decide approval state.
+          // For open review, we need detailed messages to decide approval
+          // state.
           const refetchPromise =
               entry['closed'] && entry['reviewers'].length > 0 ?
               Promise.resolve(entry) : this.doFetchOne_(entry['issue']);

--- a/src/chromeasync.js
+++ b/src/chromeasync.js
@@ -35,9 +35,9 @@ function promisify(thisArg, name) {
   return (...args) => new Promise((resolve, reject) => {
     api.call(thisArg, ...args, function(result) {
       if (chrome.runtime.lastError) {
-	// Fail.
-	reject(chrome.runtime.lastError);
-	return;
+        // Fail.
+        reject(chrome.runtime.lastError);
+        return;
       }
       // Success.
       resolve(result);

--- a/src/components/ChangeTable.js
+++ b/src/components/ChangeTable.js
@@ -139,6 +139,6 @@ class ChangeTable extends React.Component {
       </table>
     );
   }
-};
+}
 
 export default ChangeTable;

--- a/src/components/ChangeTable.js
+++ b/src/components/ChangeTable.js
@@ -54,7 +54,8 @@ const SpacingRow = () => (
 );
 
 const ChangeSubtable = ({ caption, changes }) => {
-  const rows = changes.map((change) => <ChangeRow key={change.url} change={change} />);
+  const rows = changes.map(
+      (change) => <ChangeRow key={change.url} change={change} />);
   return (
     <tbody style={{ borderTop: '0' }}>
       <HeaderRow>{ caption }</HeaderRow>
@@ -108,7 +109,8 @@ class ChangeTable extends React.Component {
       });
     });
     return (
-      <table className="table table-hover table-bordered table-condensed review-table">
+      <table className="table table-hover table-bordered table-condensed
+                        review-table">
         <colgroup>
           <col style={{ width: 'auto' }} />
           <col style={{ width: '110px' }} />

--- a/src/components/ConfigModal.js
+++ b/src/components/ConfigModal.js
@@ -190,7 +190,7 @@ class ConfigModalImpl extends React.Component {
       </Modal>
     );
   }
-};
+}
 
 const ConfigModal = ({ show, ...props }) => {
   if (!show) {

--- a/src/components/ConfigModal.js
+++ b/src/components/ConfigModal.js
@@ -137,7 +137,8 @@ class ConfigModalImpl extends React.Component {
                   label={site.label}
                   url={site.url}
                   type={site.type}
-                  onFormChange={(key, value) => this.changeSite(index, key, value)}
+                  onFormChange={
+                    (key, value) => this.changeSite(index, key, value)}
                   onRemove={() => this.removeSite(index)} />
       );
     });

--- a/src/components/PermissionModal.js
+++ b/src/components/PermissionModal.js
@@ -25,7 +25,9 @@ const PermissionModal = ({ show, sites, onContinue }) => (
       Please click the continue button and you will be asked for permissions.
     </Modal.Body>
     <Modal.Footer>
-      <Button bsStyle="primary" onClick={() => onContinue(sites)}>Continue</Button>
+      <Button bsStyle="primary" onClick={() => onContinue(sites)}>
+        Continue
+      </Button>
     </Modal.Footer>
   </Modal>
 );

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -16,9 +16,12 @@ import React from 'react';
 
 const StatusBar = ({ activeSites, onConfig }) => {
   const indicators = Object.values(activeSites).map((site) => {
-    const color = (site.loading ? 'warning' : site.success ? 'success' : 'danger');
+    const color = (
+        site.loading ? 'warning' : site.success ? 'success' : 'danger');
     return (
-      <span key={site.label} className={`label label-${color}`} style={{ margin: '1px' }}>
+      <span key={site.label}
+            className={`label label-${color}`}
+            style={{ margin: '1px' }}>
         <a href={site.url} target="_blank" style={{ color: 'white' }}>
           {site.label}
         </a>
@@ -31,11 +34,15 @@ const StatusBar = ({ activeSites, onConfig }) => {
   return (
     <div className="well well-sm">
       Sites: {' '}
-      <div style={{ display: 'inline-block', position: 'relative', top: '-2px' }}>
+      <div style={{ display: 'inline-block',
+                    position: 'relative',
+                    top: '-2px' }}>
         {indicators}
       </div>
       {spinner}
-      <a href="javascript:void(0)" style={{ color: 'inherit', float: 'right' }} onClick={onConfig}>
+      <a href="javascript:void(0)"
+         style={{ color: 'inherit', float: 'right' }}
+         onClick={onConfig}>
         <span className="glyphicon glyphicon-cog"></span>
       </a>
     </div>

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -17,38 +17,39 @@ import partialUpdate from 'react-addons-update';
 
 import * as actions from './actions';
 
+// eslint-disable-next-line no-unused-vars
 const EXAMPLE_STATE = {
   config: {
     sites: [
       {
-        label: "Label of the code review site",
-        url: "URL of the code review site top page",
-        type: "gerrit/rietveld",
+        label: 'Label of the code review site',
+        url: 'URL of the code review site top page',
+        type: 'gerrit/rietveld',
       },
       // ....
     ],
   },
-  modal: "permission/config/null",
+  modal: 'permission/config/null',
   activeSites: [
     {
-      label: "Label of the code review site",
-      url: "URL of the code review site top page",
-      type: "gerrit/rietveld",
-      loading: "true if loading from the site",
-      success: "true if loading suceeded",
+      label: 'Label of the code review site',
+      url: 'URL of the code review site top page',
+      type: 'gerrit/rietveld',
+      loading: 'true if loading from the site',
+      success: 'true if loading suceeded',
     },
     // ...
   ],
   activeChangesBySite: {
     siteLabel: {
-      owned: "true if the change is owned by the user",
-      reviewing: "true if the user is in the reviewer list",
-      subject: "Subject of the code review",
-      url: "URL of the code review entry",
-      status: "Pending/Reviewing/Approved/Submitted",
-      repository: "Description of the repository",
-      ownerName: "Name of the change owner",
-      updated: "milliseconds from UNIX epoch",
+      owned: 'true if the change is owned by the user',
+      reviewing: 'true if the user is in the reviewer list',
+      subject: 'Subject of the code review',
+      url: 'URL of the code review entry',
+      status: 'Pending/Reviewing/Approved/Submitted',
+      repository: 'Description of the repository',
+      ownerName: 'Name of the change owner',
+      updated: 'milliseconds from UNIX epoch',
     },
     // ...
   },


### PR DESCRIPTION
We may want to adopt Google JavaScript style guide eventually,
but I do not for now for several reasons:
- The style guide does not cover ES6 yet.
- Official google style eslint configuration
  (github.com/google/eslint-config-google) is too restrictive
  compared to the style guide.

Meanwhile, let's use eslint's recommended defaults + some
tweaks for Google style.

TEST=npm run lint
