### PR TITLE
Fix the Gerrit backend parsing

### DIFF
--- a/src/backends/gerrit.js
+++ b/src/backends/gerrit.js
@@ -99,7 +99,8 @@ export class GerritBackend {
       if (entry['submittable']) {
         status = 'Approved';
       } else {
-        const reviewers = entry['labels']['Code-Review']['all'] || [];
+        const reviewMetadata = entry['labels']['Code-Review'] || {};
+        const reviewers = reviewMetadata['all'] || [];
         const ownerId = entry['owner']['_account_id'];
         if (reviewers.find((user) => user['_account_id'] != ownerId) >= 0) {
           // Here non-owner user is listed.


### PR DESCRIPTION
The "Code-Review" label entry could have no value, leading to a js error
trying to lookup "all". This fixes the js error by using an empty object
if necessary.